### PR TITLE
Fix viewport not resizing properly when window is resized.

### DIFF
--- a/SpriteFactory/Sprites/SpriteEditorViewModel.cs
+++ b/SpriteFactory/Sprites/SpriteEditorViewModel.cs
@@ -557,5 +557,21 @@ namespace SpriteFactory.Sprites
                 _spriteBatch.End();
             }
         }
+
+        public override void OnSizeChanged(int width, int height)
+        {
+            base.OnSizeChanged(width, height);
+
+            //Resize the viewport with the window.
+            GraphicsDevice.Viewport = new Viewport(0, 0, width, height);
+            Vector2 lookLocation = Vector2.Zero;
+            if (Texture != null)
+            {
+                lookLocation.X += Texture.Width / 2f;
+                lookLocation.Y += Texture.Height / 2f;
+            }
+
+            Camera.LookAt(lookLocation);
+        }
     }
 }


### PR DESCRIPTION
Currently, when using SpriteFactory, if you resize the window (and therefore the embedded MonoGame control), the viewport of the MonoGame control does not change, maintaining the original size. 

If you are changing the window to a smaller size, this results in small/medium size textures not being visible when selected from the file picker, and you have to manually pan the camera and search around for it, which isn't very intuitive or user friendly.

This PR makes the viewport automatically change size when the MonoGame control is resized, and center on the currently loaded texture (if there is one), otherwise (0, 0). I don't really use WPF, so please let me know if there are any problems with the PR, I'll be happy to alter!